### PR TITLE
Update build scripts to use local Node.js installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"description": "This plugin template uses Typescript. If you are familiar with Javascript, Typescript will look very familiar. In fact, valid Javascript code is already valid Typescript code.",
 	"license": "ISC",
 	"scripts": {
-		"build": "/usr/local/bin/node node_modules/.bin/webpack --mode=production",
-		"build:watch": "/usr/local/bin/node node_modules/.bin/webpack --mode=development --watch",
+		"build": "webpack --mode=production",
+		"build:watch": "webpack --mode=development --watch",
 		"prettier:format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,json}' "
 	},
 	"dependencies": {


### PR DESCRIPTION
This pull request updates the build scripts in the `package.json` file to use the local installation of Node.js instead of hardcoding the path to the Node.js executable. The updated scripts now use the webpack command directly, which allows for more flexibility and compatibility across different development environments.

Changes Made:

- Replaced `/usr/local/bin/node` with node in the `build` and `build:watch` scripts.
- Removed unnecessary references to `node_modules/.bin` in the scripts.

These changes ensure that the build scripts will use the Node.js executable available in the local environment, making it easier for other contributors to run the build process without having to modify the scripts manually.

This update enhances the maintainability and usability of the project, and aligns with best practices for cross-platform development.